### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   ci:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/wlw-locate-kml/security/code-scanning/8](https://github.com/legnoh/wlw-locate-kml/security/code-scanning/8)

To fix the issue, we should add a `permissions:` key to the workflow file. The best approach is to add the `permissions:` block at the job level (under `ci:`) or at the root level of the workflow (above `jobs:`) to ensure that only the required permissions are provided for `GITHUB_TOKEN`. Since this workflow performs read operations (checking out code, fetching releases) and one write operation (creating a GitHub pre-release), we should minimally grant `contents: read` and `contents: write` to the job that creates releases. However, since release creation involves pull requests, assets, and release drafts, we must specifically allow `contents: read`, and `contents: write`, but can further restrict these if other permissions are not needed. As a best practice, start with `contents: read` and add `contents: write` only to the release/draft creation job or step if isolation is possible. For this workflow, as everything occurs in a single `ci` job, add the following block under `ci:` before `runs-on:`:

```yaml
permissions:
  contents: write
```

You may add additional permissions (such as `pull-requests: write`) only if required by future workflow steps. The minimal required here is `contents: write` since the workflow drafts and uploads a release. The block should be placed at line 11, with proper indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
