### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/post.yml
+++ b/.github/workflows/post.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish_tweet:
     name: tweet
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: update


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/wlw-locate-kml/security/code-scanning/1](https://github.com/legnoh/wlw-locate-kml/security/code-scanning/1)

To address the issue, an explicit `permissions` block should be added to the workflow or specific job to define the minimal privileges required for proper operation. Since the job only interacts with secrets and does not modify repository contents, the minimal required permissions are often `contents: read`. If there is no need for further permissions (such as writing issues or pull-requests, or modifying releases), granting only `contents: read` is sufficient. You should insert this block under either the workflow root (for all jobs) or directly under the `publish_tweet` job (to scope just to this job). It's usually best to put it at the job level if you're not sure whether future jobs might need different permissions.

**Change needed:**  
- In `.github/workflows/post.yml`, add a `permissions:` block under the `publish_tweet` job (after line 9), with `contents: read`.

No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
